### PR TITLE
 Fix Python 3 incompatibilities (fixes #3)

### DIFF
--- a/flask_zodb.py
+++ b/flask_zodb.py
@@ -2,7 +2,11 @@ import flask
 import transaction
 import zodburi
 
-from UserDict import IterableUserDict
+try:
+    from collections import UserDict
+except ImportError: # for Python 2
+    from UserDict import IterableUserDict as UserDict
+
 from ZODB.DB import DB
 from contextlib import contextmanager, closing
 from werkzeug.utils import cached_property
@@ -12,11 +16,17 @@ from persistent import Persistent as Object
 from persistent.list import PersistentList as List
 from persistent.mapping import PersistentMapping as Dict
 
+# Python 3 compatibility
+try:
+    basestring
+except NameError:
+    basestring = str
+
 
 __all__ = ['ZODB', 'Object', 'List', 'Dict', 'BTree']
 
 
-class ZODB(IterableUserDict):
+class ZODB(UserDict):
     """Extension object.  Behaves as the root object of the storage during
     requests, i.e. a `~persistent.mapping.PersistentMapping`.
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py25, py26, py27
+envlist = py25, py26, py27, py33, py34
 
 [testenv]
 deps = pytest


### PR DESCRIPTION
See ticket #3 for rationale.

Test for Python 3.2 with tox fails due to errors in werkzeug, so I left it out of the list of environments to test in `tox.ini`.
